### PR TITLE
Use binary filesize in serverinfo.

### DIFF
--- a/cogs/user.py
+++ b/cogs/user.py
@@ -205,7 +205,7 @@ class User(commands.Cog):
         content.add_field(name="Emojis", value=str(len(guild.emojis)))
         content.add_field(name="Boost level", value=guild.premium_tier)
         content.add_field(name="Boosts", value=guild.premium_subscription_count)
-        content.add_field(name="Filesize limit", value=humanize.naturalsize(guild.filesize_limit))
+        content.add_field(name="Filesize limit", value=humanize.naturalsize(guild.filesize_limit, binary=True))
         content.add_field(
             name="Channels",
             value=(


### PR DESCRIPTION
Discord nitro filesize limits are measured in mebibytes but Miso displays the megabyte value with the >serverinfo command.
```py
>>> humanize.naturalsize(50*(1024**2), binary=True)
'50.0 MiB'
>>> humanize.naturalsize(50*(1024**2))
'52.4 MB'
```